### PR TITLE
credit-view2(クレジット画面修正：大田)

### DIFF
--- a/app/assets/stylesheets/users/_credit.scss
+++ b/app/assets/stylesheets/users/_credit.scss
@@ -50,35 +50,37 @@
               font-weight: bold;
             }
           }
-          .inner-pay {
-            list-style: none;
-            &__box {
-              padding: 24px 0;
-              border-bottom: 1px solid #eee;
-              &--form {
-                position: relative;
-                max-width: 320px;
-                margin: 0 auto;
-                  .pay-card {
-                    vertical-align: middle;
-                  }
-                &--num {
-                  margin: 8px 0 0;
-                  font-size: 16px;
-                }
-                &--btn {
-                  position: absolute;
-                  top: 0;
-                  right: 0;
-                  padding: 4px 6px;
-                  background: #fff;
-                  border-radius: 3px;
-                  border: 1px solid #ea352d;
-                  color: #ea352d;
-                }
+        &--box {
+          padding: 24px 0;
+          border-bottom: 1px solid #eee;
+          .inner-box {
+            max-width: 320px;
+            margin: 0 auto;
+            &__link {
+              margin: 0;
+              margin-bottom: 8px !important;
+              background: #ea352d;
+              border: 1px solid #ea352d;
+              color: #fff;
+              display: block;
+              width: 100%;
+              line-height: 48px;
+              font-size: 14px;
+              cursor: pointer;
+              text-align: center;
+              text-decoration: none;
+              .far.fa-credit-card {
+                margin-right: 16px;
+                display: inline-block;
+                font-style: normal;
+                font-weight: 400;
+                font-variant: normal;
+                text-transform: none;
+                line-height: 1;
               }
             }
           }
+        }
         &--setting {
           display: block;
           margin: 40px 0 0;

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -27,19 +27,11 @@
           .inner-top
             %h3.inner-top__head
               クレジットカード一覧
-          %ul.inner-pay
-            %li.inner-pay__box
-              = form_for "", html:{class:"inner-pay__box--form"} do |f|
-                %figure
-                  = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?2787198863", width:"34", height:"20", alt:"master-card", class:"pay-card"
-                -# = f.hidden_fieldが入ります！
-                -# = f.hidden_fieldが入ります！
-                .inner-pay__box--form--num
-                  *************1111
-                .inner-pay__box--form--num
-                  01/26
-                -# = f.hidden_fieldが入ります！
-                = f.submit "削除する", class:"inner-pay__box--form--btn"
+        .cre-content__box--inner--box
+          .inner-box
+            = link_to "#", class:"inner-box__link" do
+              %i.far.fa-credit-card
+              クレジットカードを追加する
         .cre-content__box--inner--setting
           = link_to "https://www.mercari.com/jp/help_center/category/6/", class:"setting-link" do
             %span


### PR DESCRIPTION
# what
クレジット登録画面の修正（スプリントレビュー指摘箇所）

# why
マイページのクレジット画面は登録内容の表示ではなく
登録画面にlinkを飛ばすボタンのビューが必要だから。