### PR TITLE
Link and validaition(image)/リンク＆画像バリデーション：土井

### DIFF
--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -34,5 +34,9 @@ $('#post__image').change(function(){
     $('.price-group__box--bold--right').empty();
   });
 
+  // $('.btn-red').on('click', function(){
+  //   window.alert("出品が完了しました。");
+  // });
+
 });
 

--- a/app/assets/stylesheets/products/new.scss
+++ b/app/assets/stylesheets/products/new.scss
@@ -282,6 +282,38 @@
             }
           }
         }
+        .js__modal-buy{
+          display: none;
+          position: fixed;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 3000;
+          overflow-x: hidden;
+          &--back{
+            min-width: 768px;
+            margin: 20, auto;
+            width: 600px;
+            .modal-content{
+              position: relative;
+              overflow: hidden;
+              width: 95%;
+              max-width: 375px;
+              margin: 8px auto;
+              background: #fff;
+              .modal-head{
+                text-align: center;
+                line-height: 80px;
+                font-size: 18px;
+              }
+              .modal-content_body{
+                border-top: 1px solid #eee;
+                padding: 40px;
+              }
+            }
+          }
+        }
         .sellbox-form__btn{
           padding: 40px;
           border-top: 1px solid #eee;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :buy, :pay]
   before_action :set_image, only: [:show, :buy, :pay]
+  before_action :authenticate_user!, only: [:create, :edit] 
 
   def index
     @products = Product.includes(:image).order("created_at DESC")
@@ -20,14 +21,10 @@ class ProductsController < ApplicationController
 
   def create
     @product= Product.new(product_params)
-    if @product.save!
-      # あとで使う
-      # params[:images]['image'].each do |a|
-      #   @image = @product.images.create!(image: a, product_id: @product.id)
-      # end
-      redirect_to root_path, notice: '出品が完了しました。'
+    if @product.save
+      redirect_to root_path
     else
-      redirect_to new_product_path
+      redirect_to new_product_path, notice: "入力されていない項目があります。"
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,5 +3,9 @@ class Category < ApplicationRecord
   belongs_to_active_hash :genre
 
   belongs_to :product
+  validates_associated :product
+
+  validates :name_id, presence: true
+
 
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -4,7 +4,9 @@ class Delivery < ApplicationRecord
   belongs_to_active_hash :preparation
   belongs_to_active_hash :payment
 
-
   belongs_to :product
+  validates_associated :product
+  validates :payment_id, :prefecture_id, :days_to_ship_id, :mode,  presence: true
+
   
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,8 @@
 class Image < ApplicationRecord
 
   belongs_to :product
-
   mount_uploader :image, ImageUploader
+  validates_associated :product
+  validates :image, presence: true
 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,5 +13,7 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :category, update_only: true
 
   validates :name, :status, :description, :price, :condition_id, presence: true
+  validates :image, presence: true
+
 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,7 +12,6 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :delivery, update_only: true
   accepts_nested_attributes_for :category, update_only: true
 
-  # mount_uploader :image, ImageUploader
-  # enum :status, {"出品中": 0}
+  validates :name, :status, :description, :price, :condition_id, presence: true
 
 end

--- a/app/views/credits/index.html.haml
+++ b/app/views/credits/index.html.haml
@@ -2,17 +2,17 @@
 %nav.index__head-nav
   %ul
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           メルカリ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to user_path(current_user) do
         %span.index__head-nav--title
           マイページ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           支払い方法
           %i.fas.fa-chevron-right

--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -1,7 +1,7 @@
 .buy-content
   %header.buy-content__header
     %h1
-      = link_to "https://www.mercari.com/jp/" do
+      = link_to root_path do
         = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808", alt:"mercari"
   .reg-container__main
     .reg-container__main--content
@@ -55,7 +55,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -55,7 +55,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -81,7 +81,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,7 +1,7 @@
 .reg-container
   .reg-container__header
     %h1
-      =link_to 'https://www.mercari.com/jp/' do
+      =link_to root_path do
         =image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808'
     %nav.sign-up__bar
       %ol.sign-up__bar--box.clearfix
@@ -81,7 +81,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -40,7 +40,7 @@
         %li
           = link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-    = link_to root_path, {class: "footer-logo"} do
+    = link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", alt: "mercari", height: "65", width: "80"
     %p
       %small © 2019 Mercari

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,7 +1,7 @@
 .login-container
   .login-container__header
     %h1
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808"
   .login-container__main
     .login-container__main--login-panel
@@ -25,7 +25,7 @@
             =f.password_field :password, placeholder: "パスワード", class: "input-box__text input-def"
           .login-container__main--login-panel--form--input-box
           %button.submit-btn.btn-def ログイン
-          %input{type: "hidden", value: "https://www.mercari.com/jp/"}
+          %input{type: "hidden", value: root_path}
           = link_to "https://www.mercari.com/jp/password/reset/start/" do
             パスワードをお忘れの方
   .login-container__footer
@@ -40,7 +40,7 @@
         %li
           = link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-    = link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    = link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", alt: "mercari", height: "65", width: "80"
     %p
       %small © 2019 Mercari

--- a/app/views/products/_footer.html.haml
+++ b/app/views/products/_footer.html.haml
@@ -9,7 +9,7 @@
     %li
       =link_to "https://www.mercari.com/jp/tokutei/" do
         特定商取引に関する表記
-  = link_to "https://www.mercari.com/jp/", class:"footer-logo" do
+  = link_to root_path, class:"footer-logo" do
     = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808",alt: "mercari", height: "65", width: "80"
   %p
     %small © 2019 Mercari

--- a/app/views/products/_index-container.html.haml
+++ b/app/views/products/_index-container.html.haml
@@ -29,7 +29,7 @@
     .items-box-content
       - @products.first(4).each do |product|
         %section.items-box
-          = link_to root_path do
+          =link_to product_path(product.id), class: "items__box__btn" do
             %figure.items-box-photo
               = image_tag product.image.image.url, class:"img"
             .items-box-body
@@ -54,7 +54,7 @@
     .items-box-content
       - @products.first(4).each do |product|
         %section.items-box
-          = link_to root_path do
+          =link_to product_path(product.id), class: "items__box__btn" do
             %figure.items-box-photo
               = image_tag product.image.image.url, class:"img"
             .items-box-body
@@ -76,7 +76,7 @@
     .items-box-content
       - @products.first(4).each do |product|
         %section.items-box
-          = link_to root_path do
+          =link_to product_path(product.id), class: "items__box__btn" do
             %figure.items-box-photo
               = image_tag product.image.image.url, class:"img"
             .items-box-body

--- a/app/views/products/_index-footer.html.haml
+++ b/app/views/products/_index-footer.html.haml
@@ -117,12 +117,11 @@
 
       .footer__bottom
         .footer__bottom--icon
-          =link_to root_path, {class: "footer-logo"} do
+          =link_to root_path, class: "footer-logo" do
             =image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-white.svg?2927923569", alt: "mercari"
           %span.footer__bottom--copyright
             %small © 2019 Mercari
-    =link_to new_product_path, {class: "footer-sell-btn"} do
-      -# =link_to root_path, {class: "footer-sell-btn"} do
+    =link_to new_product_path, class: "footer-sell-btn" do
       %div 
         出品
       %i.fa.fa-camera.fa-lg

--- a/app/views/products/_index-footer.html.haml
+++ b/app/views/products/_index-footer.html.haml
@@ -117,11 +117,12 @@
 
       .footer__bottom
         .footer__bottom--icon
-          =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+          =link_to root_path, {class: "footer-logo"} do
             =image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-white.svg?2927923569", alt: "mercari"
           %span.footer__bottom--copyright
             %small © 2019 Mercari
     =link_to new_product_path, {class: "footer-sell-btn"} do
+      -# =link_to root_path, {class: "footer-sell-btn"} do
       %div 
         出品
       %i.fa.fa-camera.fa-lg

--- a/app/views/products/_index-footer.html.haml
+++ b/app/views/products/_index-footer.html.haml
@@ -24,25 +24,25 @@
           %h2.footer__top--head--head メルカリについて
           %ul
             %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 会社概要（運営会社）
             %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 採用情報
             %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 プレリリース
             %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 公式ブログ
             %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 メルカリロゴ利用ガイドライン
             %li.footer-link
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 %i.fab.fa-twitter
             %li.footer-link
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 %i.fab.fa-facebook-square
 
         .footer__top--head
@@ -50,28 +50,28 @@
             ヘルプ＆ガイド
             %ul
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 メルカリガイド
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 らくらくメルカリ便
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 ゆうゆうメルカリ便
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 大型メルカリ便
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 車体取引ガイド
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 メルカリあんしん・あんぜん宣言！
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 偽ブランド品撲滅への取り組み
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 メルカリボックス
         .footer__top--head.width
           %h2.footer__top--head--head
@@ -79,40 +79,40 @@
           .footer__top--head--inner
             %ul
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 プライバシーポリシー
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 メルカリ利用規約
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 あんしんスマホサポート制度に関する利用特約
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 コンプライアンスポリシー
           .footer__top--head--inner
             %ul
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 個人データの安全管理に係る基本方針
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 特定商取引に関する表記
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 資金決済法に基づく表示
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 法令順守と犯罪抑止のために
         .footer__top--head.footer-nav-lang
           %h2.footer__top--head--head 
             国
             %ul
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 日本
               %li
-              =link_to "https://www.mercari.com/jp/" do
+              =link_to root_path do
                 United States
 
       .footer__bottom

--- a/app/views/products/_index-header-list.html.haml
+++ b/app/views/products/_index-header-list.html.haml
@@ -2,7 +2,7 @@
   .index-header-inner
     .index-header-top
       %h1
-        = link_to "https://www.mercari.com/jp/" do
+        = link_to root_path do
           = image_tag("https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3135490372")
       %form.index-header-form
         %input.index-input-default{type: "search", name: "keyword", placeholder: "何かお探しですか？"}
@@ -12,12 +12,12 @@
         %ul.header-navigation
           %li
             %h2
-              = link_to "https://www.mercari.com/jp/category/", {class: "header-navigation-list-parent"} do
+              = link_to "", {class: "header-navigation-list-parent"} do
                 %i.fas.fa-bars
                 %span カテゴリーから探す
           %li
             %h2
-              = link_to "https://www.mercari.com/jp/brand/", {class: "header-navigation-list-parent"} do
+              = link_to "", {class: "header-navigation-list-parent"} do
                 %i.fas.fa-tags
                 %span ブランドから探す
       .index-right-content

--- a/app/views/products/_index-header-list.html.haml
+++ b/app/views/products/_index-header-list.html.haml
@@ -12,18 +12,18 @@
         %ul.header-navigation
           %li
             %h2
-              = link_to "", {class: "header-navigation-list-parent"} do
+              = link_to "", class: "header-navigation-list-parent" do
                 %i.fas.fa-bars
                 %span カテゴリーから探す
           %li
             %h2
-              = link_to "", {class: "header-navigation-list-parent"} do
+              = link_to "", class: "header-navigation-list-parent" do
                 %i.fas.fa-tags
                 %span ブランドから探す
       .index-right-content
         %ul.header-login-navigation
           %li
-            = link_to '新規会員登録', select_sign_up_users_path, {class: "index-header-btn btn-red"}
+            = link_to '新規会員登録', select_sign_up_users_path, class: "index-header-btn btn-red"
           %li
-            = link_to 'ログイン', new_user_session_path, {class: "index-header-btn header-login"}
+            = link_to 'ログイン', new_user_session_path, class: "index-header-btn header-login"
 

--- a/app/views/products/_index-header.html.haml
+++ b/app/views/products/_index-header.html.haml
@@ -21,8 +21,8 @@
                 %br
                 購入時も安心な独自システムのアプリです
               .top-main-visual-btn.clearfix
-                = link_to "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", {class: "left-left"} do
+                = link_to "https://itunes.apple.com/jp/app/id667861049?l=ja&mt=8", class: "left-left" do
                   %img{src: "//www-mercari-jp.akamaized.net/assets/img/common/common/app-store.svg?3125985667"}
-                = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", {class: "left-left"} do
+                = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", class: "left-left" do
                   %img{src: "//www-mercari-jp.akamaized.net/assets/img/common/common/google-play.svg?3125985667"}    
             %img{src: "//www-mercari-jp.akamaized.net/assets/img/common/jp/top/main_content_pc.png?3125985667", class: "index-slider-image"}

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -1,7 +1,7 @@
 .buy-content
   %header.buy-content__header
     %h1
-      = link_to "https://www.mercari.com/jp/" do
+      = link_to root_path do
         = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808", alt:"mercari"
   .buy-content__main
     %section.buy-content__main--box

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,7 +1,7 @@
 .new-content
   %header.new-content__header
     %h1
-      = link_to "https://www.mercari.com/jp/" do
+      = link_to root_path do
         = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808", alt:"mercari"
   .new-content__main
     %section.new-content__main--sellbox
@@ -181,7 +181,7 @@
         %li
           =link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-      = link_to "https://www.mercari.com/jp/", class:"footer-logo" do
+      = link_to root_path, class:"footer-logo" do
         = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808",alt: "mercari", height: "65", width: "80"
       %p
         %small © 2019 Mercari

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -8,7 +8,7 @@
       %h2.sellbox-head
         商品の情報を編集
         -#フォーム始まり 
-      = form_for @product, url: product_path(@product.id), html:{class: "sellbox-form"} do |f|
+      = form_for @product, url: product_path(@product.id), class: "sellbox-form" do |f|
         .sellbox-form__upload
           %h3.sellbox-form__upload--head
             出品画像
@@ -22,7 +22,7 @@
                 %ul
                   %li.upload-image__prev
                     %figure.upload-image__prev--figure
-                      =image_tag(@product.image.image.url, {class: "upload-image__prev--figure--src"})
+                      =image_tag(@product.image.image.url, class: "upload-image__prev--figure--src")
                     %button.upload-image__prev--btn
                       =link_to "編集"
                       =link_to "削除"

--- a/app/views/products/exhibit.html.haml
+++ b/app/views/products/exhibit.html.haml
@@ -2,15 +2,15 @@
 %nav.user-navigation
   %ul
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to root_path, itemprop: "url" do
         %span メルカリ
       %i.fas.fa-angle-right
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to user_path(current_user), itemprop: "url" do
         %span マイページ
       %i.fas.fa-angle-right
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to item_state_users_path, itemprop: "url" do
         %span 出品した商品 - 出品中
       %i.fas.fa-angle-right
     %li

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -11,7 +11,7 @@
       %h2.sellbox-head
         商品の情報を入力
         -#フォーム始まり 
-      = form_for @product, url: '/products', html:{class: "sellbox-form"} do |f|
+      = form_for @product, url: '/products', class: "sellbox-form" do |f|
         .sellbox-form__upload
           %h3.sellbox-form__upload--head
             出品画像
@@ -25,7 +25,7 @@
                 %ul
                   %li.upload-image__prev
                     %figure.upload-image__prev--figure
-                      =image_tag "", {class: "upload-image__prev--figure--src"}
+                      =image_tag "", class: "upload-image__prev--figure--src"
                     %button.upload-image__prev--btn
                       =link_to "編集"
                       =link_to "削除"

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,8 +1,11 @@
 .new-content
   %header.new-content__header
     %h1
-      = link_to "https://www.mercari.com/jp/" do
+      = link_to root_path do
         = image_tag "https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808", alt:"mercari"
+    - if flash[:notice]
+      %p
+        = flash[:notice] 
   .new-content__main
     %section.new-content__main--sellbox
       %h2.sellbox-head
@@ -139,6 +142,15 @@
                   販売利益
                 .price-group__box--bold--right
                   &minus;
+                  -# モーダルウィンドウ//始まり
+        .js__modal-buy
+          .js__model-buy--back
+            .modal-content
+              %h3.modal-head 出品が完了しました
+              .modal-content_body
+                あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。
+                -# =link_to "続けて出品する", new_product_path, class: "btn-red" do
+                  -# モーダルウィンドウ//終わり
         .sellbox-form__btn
           %div
             %p
@@ -180,7 +192,7 @@
         %li
           =link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-      = link_to "https://www.mercari.com/jp/", class:"footer-logo" do
+      = link_to root_path, class:"footer-logo" do
         = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808",alt: "mercari", height: "65", width: "80"
       %p
         %small © 2019 Mercari

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -129,7 +129,8 @@
     %section.items-box-container.items-in-user-profile 
     
       %h2.items-box-head
-        = @user.name  + "さんのその他の出品"
+        = @user.name
+        さんのその他の出品
       .items-box-content__clearfix
         %section.items-box
           = link_to root_path do

--- a/app/views/users/_indexheader.html.haml
+++ b/app/views/users/_indexheader.html.haml
@@ -13,12 +13,12 @@
           %ul.header-navigation
             %li
               %h2
-                = link_to root_path, {class: "header-navigation-list-parent"} do
+                = link_to root_path, class: "header-navigation-list-parent" do
                   %i.fas.fa-bars
                   %span カテゴリーから探す
             %li
               %h2
-                = link_to root_path, {class: "header-navigation-list-parent"} do
+                = link_to root_path, class: "header-navigation-list-parent" do
                   %i.fas.fa-tags
                   %span ブランドから探す
         .index-right-content

--- a/app/views/users/_indexheader.html.haml
+++ b/app/views/users/_indexheader.html.haml
@@ -13,12 +13,12 @@
           %ul.header-navigation
             %li
               %h2
-                = link_to "https://www.mercari.com/jp/category/", {class: "header-navigation-list-parent"} do
+                = link_to root_path, {class: "header-navigation-list-parent"} do
                   %i.fas.fa-bars
                   %span カテゴリーから探す
             %li
               %h2
-                = link_to "https://www.mercari.com/jp/brand/", {class: "header-navigation-list-parent"} do
+                = link_to root_path, {class: "header-navigation-list-parent"} do
                   %i.fas.fa-tags
                   %span ブランドから探す
         .index-right-content

--- a/app/views/users/_mypage_side_nav.html.haml
+++ b/app/views/users/_mypage_side_nav.html.haml
@@ -17,7 +17,7 @@
         いいね!一覧
         %i.fas.fa-angle-right.fa-2x
     %li
-      = link_to user_path(current_user), class: "user-side-navigation__list--item"do
+      = link_to new_product_path(current_user), class: "user-side-navigation__list--item"do
         出品する
         %i.fas.fa-angle-right.fa-2x
     %li
@@ -71,7 +71,7 @@
     設定
   %ul.user-side-navigation__list
     %li
-      = link_to user_path(current_user), class: "user-side-navigation__list--item" do
+      = link_to profile_users_path(current_user), class: "user-side-navigation__list--item" do
         プロフィール
         %i.fas.ffa-angle-right
     %li
@@ -87,7 +87,7 @@
         メール/パスワード
         %i.fas.fa-angle-right.fa-2x
     %li
-      = link_to user_path(current_user), class: "user-side-navigation__list--item" do
+      = link_to detail_users_path(current_user), class: "user-side-navigation__list--item" do
         本人情報
         %i.fas.fa-angle-right.fa-2x
     %li

--- a/app/views/users/_user_header.html.haml
+++ b/app/views/users/_user_header.html.haml
@@ -1,7 +1,7 @@
 .reg-container
   .reg-container__header
     %h1
-      =link_to 'https://www.mercari.com/jp/' do
+      =link_to root_path do
         =image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808'
     %nav.sign-up__bar
       %ol.sign-up__bar--box.clearfix

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -2,17 +2,17 @@
 %nav.index__head-nav
   %ul
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           メルカリ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to user_path(current_user) do
         %span.index__head-nav--title
           マイページ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           支払い方法
           %i.fas.fa-chevron-right

--- a/app/views/users/detail.html.haml
+++ b/app/views/users/detail.html.haml
@@ -3,7 +3,7 @@
     .index-header-inner
       .index-header-top
         %h1
-          = link_to "https://www.mercari.com/jp/" do
+          = link_to root_path do
             =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3135490372"
         %form.index-header-form
           %input.index-input-default{type: "search", name: "keyword", placeholder: "何かお探しですか？"}
@@ -13,28 +13,28 @@
           %ul.header-navigation
             %li
               %h2
-                = link_to "https://www.mercari.com/jp/category/", {class: "header-navigation-list-parent"} do
+                = link_to root_path, {class: "header-navigation-list-parent"} do
                   %i.fas.fa-bars
                   %span カテゴリーから探す
             %li
               %h2
-                = link_to "https://www.mercari.com/jp/brand/", {class: "header-navigation-list-parent"} do
+                = link_to root_path, {class: "header-navigation-list-parent"} do
                   %i.fas.fa-tags
                   %span ブランドから探す
         .index-right-content
           %ul.header-login-navigation
             %li
-              = link_to '新規会員登録', "https://www.mercari.com/jp/signup/", {class: "index-header-btn btn-red"}
+              = link_to '新規会員登録', new_user_path, {class: "index-header-btn btn-red"}
             %li
-              = link_to 'ログイン', "https://www.mercari.com/jp/login/?login_callback=https%3A%2F%2Fwww.mercari.com%2Fjp%2F", {class: "index-header-btn header-login"}
+              = link_to 'ログイン', new_user_session_path, {class: "index-header-btn header-login"}
 %nav.user-navigation
   %ul
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to root_path, itemprop: "url" do
         %span メルカリ
       %i.fas.fa-angle-right
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to user_path(current_user), itemprop: "url" do
         %span マイページ
       %i.fas.fa-angle-right
     %li

--- a/app/views/users/detail.html.haml
+++ b/app/views/users/detail.html.haml
@@ -13,20 +13,20 @@
           %ul.header-navigation
             %li
               %h2
-                = link_to root_path, {class: "header-navigation-list-parent"} do
+                = link_to root_path, class: "header-navigation-list-parent" do
                   %i.fas.fa-bars
                   %span カテゴリーから探す
             %li
               %h2
-                = link_to root_path, {class: "header-navigation-list-parent"} do
+                = link_to root_path, class: "header-navigation-list-parent" do
                   %i.fas.fa-tags
                   %span ブランドから探す
         .index-right-content
           %ul.header-login-navigation
             %li
-              = link_to '新規会員登録', new_user_path, {class: "index-header-btn btn-red"}
+              = link_to '新規会員登録', new_user_path, class: "index-header-btn btn-red"
             %li
-              = link_to 'ログイン', new_user_session_path, {class: "index-header-btn header-login"}
+              = link_to 'ログイン', new_user_session_path, class: "index-header-btn header-login"
 %nav.user-navigation
   %ul
     %li
@@ -44,7 +44,7 @@
   .user-edit-container__right-content
     %section.mypage-identification
       %h2.mypage-identification__mypage-text 本人情報の登録
-      = form_for "/", html:{class: "edit-form-contents", method: :post} do |f|
+      = form_for "/", class: "edit-form-contents", method: :post do |f|
         .edit-form-contents__warning-message
           %p
             お客さまの本人情報をご登録ください

--- a/app/views/users/item_state.html.haml
+++ b/app/views/users/item_state.html.haml
@@ -2,11 +2,11 @@
 %nav.user-navigation
   %ul
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to root_path, itemprop: "url" do
         %span メルカリ
       %i.fas.fa-angle-right
     %li
-      = link_to "/", itemprop: "url" do
+      = link_to user_path(current_user), itemprop: "url" do
         %span マイページ
       %i.fas.fa-angle-right
     %li

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -2,17 +2,17 @@
 %nav.index__head-nav
   %ul
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           メルカリ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           マイページ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           プロフィール
           %i.fas.fa-chevron-right

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -22,7 +22,7 @@
     %section.pro-content__box
       %h2.pro-content__box--head
         プロフィール
-      = form_for "", html:{class: "pro-content__box--form"} do |f|
+      = form_for "", class: "pro-content__box--form" do |f|
         .profile-icon
           %figure
             = image_tag "http://static.mercdn.net/images/member_photo_noimage_thumb.png", class:"profile-icon__image", width:"60", heght:"60"

--- a/app/views/users/select_sign_up.html.haml
+++ b/app/views/users/select_sign_up.html.haml
@@ -1,7 +1,7 @@
 .container
   .container__header
     %h1
-      = link_to "https://www.mercari.com/jp/" do
+      = link_to root_path do
         = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2098311808"
   .container__main
     .container__main--section
@@ -30,7 +30,7 @@
         %li
           = link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-    = link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    = link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", alt: "mercari", height: "65", width: "80"
     %p
       %small © 2019 Mercari

--- a/app/views/users/select_sign_up.html.haml
+++ b/app/views/users/select_sign_up.html.haml
@@ -8,7 +8,7 @@
       %h2.container__main--section--title 新規会員登録
       .select-form
         .select-form__content
-          = link_to new_user_registration_path, {class: "mail-btn"} do
+          = link_to new_user_registration_path, class: "mail-btn" do
             %i.far.fa-envelope
             メールアドレスで登録する
           %button#facebook.btn-def.btn-sns
@@ -30,7 +30,7 @@
         %li
           = link_to "https://www.mercari.com/jp/tokutei/" do
             特定商取引に関する表記
-    = link_to root_path, {class: "footer-logo"} do
+    = link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", alt: "mercari", height: "65", width: "80"
     %p
       %small © 2019 Mercari

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -4,7 +4,7 @@
     = render 'users/mypage_side_nav'
     .show-container__main--content
       %section.show-container__main--content--user-icon
-        =link_to "https://www.mercari.com/jp/" do
+        =link_to root_path do
           %figure.user-icon__avater
             = image_tag 'https://static.mercdn.net/images/member_photo_noimage_thumb.png'
           %h2.user-icon__avater--name 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -30,7 +30,7 @@
           %ul.tab-notification
             -# あとで使う
             -# %li
-            -#   =link_to 'https://www.mercari.com/jp/' do {class: "tab-links"}
+            -#   =link_to 'https://www.mercari.com/jp/', class: "tab-links" do
             -#     %figure
             -#       = image_tag '//static.mercdn.net/images/mercari_profile.png', class: "small-mercari"
             -#     .tab-body
@@ -44,7 +44,7 @@
             -# %li.all-notifications 一覧を見る
           -# %ul.tab-todo
           -#   %li
-          -#     =link_to 'https://www.mercari.com/jp/' do {class: "tab-links"}
+          -#     =link_to 'https://www.mercari.com/jp/', class: "tab-links" do
           -#       %figure
           -#         = image_tag '//static.mercdn.net/images/mercari_profile.png', class: "small-mercari"
           -#       .tab-body

--- a/app/views/users/sign_up_fifth.html.haml
+++ b/app/views/users/sign_up_fifth.html.haml
@@ -24,7 +24,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_fifth.html.haml
+++ b/app/views/users/sign_up_fifth.html.haml
@@ -24,7 +24,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_forth.html.haml
+++ b/app/views/users/sign_up_forth.html.haml
@@ -51,7 +51,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_forth.html.haml
+++ b/app/views/users/sign_up_forth.html.haml
@@ -51,7 +51,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_second.html.haml
+++ b/app/views/users/sign_up_second.html.haml
@@ -31,7 +31,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_second.html.haml
+++ b/app/views/users/sign_up_second.html.haml
@@ -31,7 +31,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_third.html.haml
+++ b/app/views/users/sign_up_third.html.haml
@@ -55,7 +55,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to "https://www.mercari.com/jp/", {class: "footer-logo"} do
+    =link_to root_path, {class: "footer-logo"} do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/sign_up_third.html.haml
+++ b/app/views/users/sign_up_third.html.haml
@@ -55,7 +55,7 @@
         %li
           =link_to 'https://www.mercari.com/jp/tokutei/' do
             %p 特定商取引に関する表記
-    =link_to root_path, {class: "footer-logo"} do
+    =link_to root_path, class: "footer-logo" do
       =image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2098311808", {alt: "mercari", height: "65", width: "80"}
     %p
       %small ©2019 Mercari

--- a/app/views/users/signout.html.haml
+++ b/app/views/users/signout.html.haml
@@ -2,17 +2,17 @@
 %nav.index__head-nav
   %ul
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to root_path do
         %span.index__head-nav--title
           メルカリ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to user_path(current_user) do
         %span.index__head-nav--title
           マイページ
           %i.fas.fa-chevron-right
     %li
-      =link_to "https://www.mercari.com/jp/" do
+      =link_to destroy_user_session do
         %span.index__head-nav--title
           ログアウト
           %i.fas.fa-chevron-right


### PR DESCRIPTION
## What

各ページのリンクを設定、出品画面のバリデーション設定

## Why

本物のメルカリのリンクが混在しているため、画像なしでも出品できてしまうため

## Gyazo
出品入力（画像なし）
https://gyazo.com/a0574822011947db3aa44992d638e696
出品入力（続き）
https://gyazo.com/76202d6b7722a2d5becbe6fc08d2d6b1
出品ボタンですとエラーメッセージ出ます
https://gyazo.com/f4abbd3fad7f0c043305269dd6503280
