### PR TITLE
Payjp(payjp修正：大田)

### DIFF
--- a/app/assets/stylesheets/products/show.scss
+++ b/app/assets/stylesheets/products/show.scss
@@ -23,7 +23,7 @@
   .item-box-container{
     width: 620px;
     padding: 24px 40px 40px;
-    margin: 40px 370px;
+    margin: 40px auto;
     background-color: white;
     &__single-sontainer{
       .item-name{

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -11,7 +11,7 @@ class CreditsController < ApplicationController
     if @credit.blank?
       redirect_to action: "new" 
     else
-      Payjp.api_key = 'sk_test_634d5041b80a0c0fca6d2552'
+      Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
       customer = Payjp::Customer.retrieve(@credit.payjp_id)
       @default_credit_info = customer.cards.retrieve(@credit.card_id)
       @card_nam = @default_credit_info.last4
@@ -21,7 +21,7 @@ class CreditsController < ApplicationController
   end
 
   def create 
-    Payjp.api_key = 'sk_test_634d5041b80a0c0fca6d2552'
+    Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -38,7 +38,7 @@ class CreditsController < ApplicationController
   end
 
   def destroy
-    Payjp.api_key = 'sk_test_634d5041b80a0c0fca6d2552'
+    Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
     customer = Payjp::Customer.retrieve(@credit.payjp_id)
     customer.delete
     if @credit.destroy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -46,23 +46,24 @@ class ProductsController < ApplicationController
 
 
   def buy
+    @credit = Credit.where(user_id: current_user.id).first if Credit.where(user_id: current_user.id).present?
     if @product.seller_id == current_user.id
       redirect_to product_path(@product)
+    elsif @credit.blank?
+      redirect_to credit_users_path
     else
-    ## payjp情報
-    @credit = Credit.where(user_id: current_user.id).first if Credit.where(user_id: current_user.id).present?
-    Payjp.api_key = 'sk_test_634d5041b80a0c0fca6d2552'
-    customer = Payjp::Customer.retrieve(@credit.payjp_id)
-    @default_credit_info = customer.cards.retrieve(@credit.card_id)
-    @card_nam = @default_credit_info.last4
-    @exp_month = @default_credit_info.exp_month
-    @exp_year = @default_credit_info.exp_year.to_s.slice(2,3)
+      Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
+      customer = Payjp::Customer.retrieve(@credit.payjp_id)
+      @default_credit_info = customer.cards.retrieve(@credit.card_id)
+      @card_nam = @default_credit_info.last4
+      @exp_month = @default_credit_info.exp_month
+      @exp_year = @default_credit_info.exp_year.to_s.slice(2,3)
     end
   end
 
   def pay
     credit = Credit.where(user_id: current_user.id).first
-    Payjp.api_key = 'sk_test_634d5041b80a0c0fca6d2552'
+    Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
     Payjp::Charge.create(
     amount: @product.price, 
     customer: credit.payjp_id, 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @credit = Credit.where(user_id: current_user.id).first if Credit.where(user_id: current_user.id).present?
   end
 
   def select_sign_up
@@ -26,6 +27,7 @@ class UsersController < ApplicationController
   end
 
   def credit
+    @credit = Credit.where(user_id: current_user.id).first if Credit.where(user_id: current_user.id).present?
   end
   
   def signout

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -13,7 +13,7 @@
             = image_tag @image.image.url,class:"item-inner__image--photo"
           %p.item-inner__name
             = @product.name
-          = form_with url:"/products/pay/#{@product.id}",class:"item-inner__form", method: :post do |f|
+          = form_with url: pay_products_path(@product),class:"item-inner__form", method: :post do |f|
             %p.price
               = "¥#{@product.price}"
               %span.price__fee

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -84,7 +84,7 @@
           （税込）
         %span.item-shipping-fee
           送料込み
-      = link_to "/products/buy/#{@product.id}",product_id:@product.id, class:"item-buy-btn" do
+      = link_to buy_products_path(@product), class:"item-buy-btn" do
         購入を確定する
       .item-description
         %p.item-description__inner

--- a/app/views/users/_mypage_side_nav.html.haml
+++ b/app/views/users/_mypage_side_nav.html.haml
@@ -79,9 +79,14 @@
         発送元・お届け先住所変更
         %i.fas.fa-angle-right.fa-2x
     %li
-      = link_to credit_users_path(current_user), class: "user-side-navigation__list--item" do
-        支払い方法
-        %i.fas.fa-angle-right.fa-2x
+      -if @credit.present?
+        = link_to credits_path, class: "user-side-navigation__list--item" do
+          支払い方法
+          %i.fas.fa-angle-right.fa-2x
+      - else
+        = link_to credit_users_path, class: "user-side-navigation__list--item" do
+          支払い方法
+          %i.fas.fa-angle-right.fa-2x
     %li
       = link_to user_path(current_user), class: "user-side-navigation__list--item" do
         メール/パスワード

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,8 +25,8 @@ Rails.application.routes.draw do
   end
   resources :products, only: [:index, :new, :show, :create, :edit, :update] do
     collection do
-      get 'buy/:id' => 'products#buy' 
-      get 'pay/:id' => 'products#pay'
+      get 'buy/:id' => 'products#buy', as: 'buy'
+      get 'pay/:id' => 'products#pay', as: 'pay'
     end
   end
 


### PR DESCRIPTION
## what
マイページの支払方法へのリンク変更
クレジット情報が登録されていない場合購入画面に進めないように条件分岐

## why
リンク先が正しくなかったため
クレジット情報を登録しないまま購入を行うとエラーになるため